### PR TITLE
Manage the wellcomeimages certificate in Terraform

### DIFF
--- a/terraform/certs.tf
+++ b/terraform/certs.tf
@@ -10,3 +10,32 @@ resource "aws_acm_certificate" "wellcomeimages" {
     create_before_destroy = true
   }
 }
+
+data "aws_route53_zone" "wellcomeimages" {
+  provider = aws.dns
+
+  name = "wellcomeimages.org."
+}
+
+resource "aws_route53_record" "wellcomeimages" {
+  provider = aws.dns
+
+  for_each = {
+    for dvo in aws_acm_certificate.wellcomeimages.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  ttl     = 300
+  type    = each.value.type
+  zone_id = data.aws_route53_zone.wellcomeimages.zone_id
+}
+
+resource "aws_acm_certificate_validation" "wellcomeimages" {
+  certificate_arn         = aws_acm_certificate.wellcomeimages.arn
+  validation_record_fqdns = [for record in aws_route53_record.wellcomeimages : record.fqdn]
+}

--- a/terraform/certs.tf
+++ b/terraform/certs.tf
@@ -1,0 +1,12 @@
+resource "aws_acm_certificate" "wellcomeimages" {
+  domain_name       = "wellcomeimages.org"
+  validation_method = "DNS"
+
+  subject_alternative_names = [
+    "*.wellcomeimages.org",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,19 +1,3 @@
-# Lookup certificate to use ARN later on
-/*data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  domain = "wellcomecollection.org"
-}*/
-
-# If you use the lookup above, you get an error from Terraform:
-#
-#     Error: Multiple certificates for domain "wellcomecollection.org" found
-#     in this region
-#
-# For now I've hard-coded the ARN that was already in use, but long-term we
-# should probably fix the certificates so we can use the data block again.
-locals {
-  acm_certificate_arn = "arn:aws:acm:us-east-1:130871440101:certificate/ef52a10d-1c6b-4612-974c-f64a15e0d8af"
-}
-
 resource "aws_cloudfront_distribution" "wellcomeimages" {
   origin {
     domain_name = "wellcomeimages.org"
@@ -66,7 +50,7 @@ resource "aws_cloudfront_distribution" "wellcomeimages" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = local.acm_certificate_arn
+    acm_certificate_arn      = aws_acm_certificate.wellcomeimages.arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1"
   }

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -11,7 +11,7 @@
 # For now I've hard-coded the ARN that was already in use, but long-term we
 # should probably fix the certificates so we can use the data block again.
 locals {
-  acm_certificate_arn = "arn:aws:acm:us-east-1:130871440101:certificate/9b4d357e-689f-4fd3-bf12-4e6c5fd4af35"
+  acm_certificate_arn = "arn:aws:acm:us-east-1:130871440101:certificate/ef52a10d-1c6b-4612-974c-f64a15e0d8af"
 }
 
 resource "aws_cloudfront_distribution" "wellcomeimages" {

--- a/terraform/edge_lambdas.tf
+++ b/terraform/edge_lambdas.tf
@@ -20,13 +20,6 @@ resource "aws_iam_role" "edge_lambda_role" {
   tags = local.default_tags
 }
 
-resource "aws_s3_bucket" "wellcomeimages" {
-  bucket = "wellcomeimages"
-  acl    = "private"
-
-  tags = local.default_tags
-}
-
 resource "aws_lambda_function" "edge_lambda_request" {
   function_name = "wellcomeimages_edge_lambda_request"
   role          = aws_iam_role.edge_lambda_role.arn

--- a/terraform/edge_lambdas.tf
+++ b/terraform/edge_lambdas.tf
@@ -27,20 +27,11 @@ resource "aws_s3_bucket" "wellcomeimages" {
   tags = local.default_tags
 }
 
-# data "aws_s3_bucket_object" "edge_lambda_origin" {
-#   bucket = "wellcomeimages"
-#   key    = "lambdas/edge_lambda_origin.zip"
-# }
-
 resource "aws_lambda_function" "edge_lambda_request" {
   function_name = "wellcomeimages_edge_lambda_request"
   role          = aws_iam_role.edge_lambda_role.arn
   runtime       = "nodejs8.10"
   handler       = "edge_lambda_origin.handler"
-
-  # s3_bucket         = "${aws_s3_bucket_object.edge_lambda_request.bucket}"
-  # s3_key            = "edge_lambda_origin.zip"
-  # s3_object_version = "${data.aws_s3_bucket_object.edge_lambda_origin.version_id}"
 
   filename         = "../lambdas/edge_lambda_origin.zip"
   source_code_hash = filebase64sha256("../lambdas/edge_lambda_origin.zip")

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -11,3 +11,13 @@ locals {
     TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomeimages/tree/master/terraform"
   }
 }
+
+provider "aws" {
+  region  = "eu-west-1"
+  version = "~> 2.69"
+  alias   = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -10,15 +10,3 @@ terraform {
     bucket         = "wellcomecollection-infra"
   }
 }
-
-data "terraform_remote_state" "router" {
-  backend = "s3"
-
-  config = {
-    role_arn = "arn:aws:iam::130871440101:role/experience-read_only"
-
-    bucket = "wellcomecollection-infra"
-    key    = "build-state/router.tfstate"
-    region = "eu-west-1"
-  }
-}


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/4860

Based on reading [the Terraform docs for aws_acm_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate), then importing resources until Terraform planned with no changes.