### PR TITLE
decouple lambda from cf function association

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.61.0"
+  version = "5.82.2"
   hashes = [
-    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
+    "h1:ce6Dw2y4PpuqAPtnQ0dO270dRTmwEARqnfffrE1VYJ8=",
+    "zh:0262fc96012fb7e173e1b7beadd46dfc25b1dc7eaef95b90e936fc454724f1c8",
+    "zh:397413613d27f4f54d16efcbf4f0a43c059bd8d827fe34287522ae182a992f9b",
+    "zh:436c0c5d56e1da4f0a4c13129e12a0b519d12ab116aed52029b183f9806866f3",
+    "zh:4d942d173a2553d8d532a333a0482a090f4e82a2238acf135578f163b6e68470",
+    "zh:624aebc549bfbce06cc2ecfd8631932eb874ac7c10eb8466ce5b9a2fbdfdc724",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e632dee2dfdf01b371cca7854b1ec63ceefa75790e619b0642b34d5514c6733",
+    "zh:a07567acb115b60a3df8f6048d12735b9b3bcf85ec92a62f77852e13d5a3c096",
+    "zh:ab7002df1a1be6432ac0eb1b9f6f0dd3db90973cd5b1b0b33d2dae54553dfbd7",
+    "zh:bc1ff65e2016b018b3e84db7249b2cd0433cb5c81dc81f9f6158f2197d6b9fde",
+    "zh:bcad84b1d767f87af6e1ba3dc97fdb8f2ad5de9224f192f1412b09aba798c0a8",
+    "zh:cf917dceaa0f9d55d9ff181b5dcc4d1e10af21b6671811b315ae2a6eda866a2a",
+    "zh:d8e90ecfb3216f3cc13ccde5a16da64307abb6e22453aed2ac3067bbf689313b",
+    "zh:d9054e0e40705df729682ad34c20db8695d57f182c65963abd151c6aba1ab0d3",
+    "zh:ecf3a4f3c57eb7e89f71b8559e2a71e4cdf94eea0118ec4f2cb37e4f4d71a069",
   ]
 }

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "wellcomeimages" {
 
     lambda_function_association {
       event_type = "origin-request"
-      lambda_arn = aws_lambda_function.edge_lambda_request.qualified_arn
+      lambda_arn = "${aws_lambda_function.edge_lambda_request.arn}:8"
     }
   }
 

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "wellcomeimages" {
 
     lambda_function_association {
       event_type = "origin-request"
-      lambda_arn = "${aws_lambda_function.edge_lambda_request.arn}:8"
+      lambda_arn = "${aws_lambda_function.edge_lambda_request.arn}:9"
     }
   }
 

--- a/terraform/edge_lambdas.tf
+++ b/terraform/edge_lambdas.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_log_group" "edge_lambda" {
 resource "aws_lambda_function" "edge_lambda_request" {
   function_name = "wellcomeimages_edge_lambda_request"
   role          = aws_iam_role.edge_lambda_role.arn
-  runtime       = "nodejs8.10"
+  runtime       = "nodejs20.x"
   handler       = "edge_lambda_origin.handler"
 
   description = "Redirects requests from wellcomeimages.org"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,8 +2,10 @@ terraform {
   required_version = ">= 0.11.10"
 
   backend "s3" {
-    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
-
+    assume_role = {
+      role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+    }
+    
     key            = "build-state/wellcomeimages.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -5,7 +5,6 @@ terraform {
     assume_role = {
       role_arn = "arn:aws:iam::130871440101:role/experience-developer"
     }
-    
     key            = "build-state/wellcomeimages.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"


### PR DESCRIPTION
## What does this change?

Explicitly set the version used in the distro. 
Create a new version of the lambda with node20

Next steps:
- apply this tf to create v9 of the lambda
- bump the fn association to "${aws_lambda_function.edge_lambda_request.arn}:9" and apply
- test a few redirects

If testing is successful, merge as is
If not we can revert to "${aws_lambda_function.edge_lambda_request.arn}:8" and apply

## How to test

Handler tested locally with node20 and the provided test json
There is only the production distro so no option to test in stage

## How can we measure success?

The lambda run on node20 and redirects successfully from wellcomeimages.org

## Have we considered potential risks?

It could break wellcomeimages.org redirects but it'll be easy and quick to revert to v8

